### PR TITLE
Update RPICT7V1.json

### DIFF
--- a/app/rpict/device-mapping/RPICT7V1.json
+++ b/app/rpict/device-mapping/RPICT7V1.json
@@ -40,37 +40,37 @@
     },
     "Irms1": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms2": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms3": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms4": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms5": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms6": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Irms7": {
         "type": "float",
-        "unit_of_measurement": "mA",
+        "unit_of_measurement": "A",
         "device_class": "current"
     },
     "Vrms": {


### PR DESCRIPTION
Updated Irms units from mA to A at least for RPICT7V1 Version 5. All outputs type available are
Vrms (V)
Irms (A)
Real Power (W)